### PR TITLE
Fix BiasBatchNorm2d implementation

### DIFF
--- a/attorch/layers.py
+++ b/attorch/layers.py
@@ -221,7 +221,8 @@ class WidthXHeightXFeatureLinear(nn.Module):
 
 class BiasBatchNorm2d(nn.BatchNorm2d):
     def __init__(self, features, **kwargs):
-        super().__init__(features, affine=False, **kwargs)
+        kwargs['affine'] = False
+        super().__init__(features, **kwargs)
         self.bias = nn.Parameter(torch.FloatTensor(1, features, 1, 1))
         self.initialize()
 
@@ -229,7 +230,5 @@ class BiasBatchNorm2d(nn.BatchNorm2d):
         self.bias.data.fill_(0)
 
     def forward(self, input):
-        self._check_input_dim(input)
-        return F.batch_norm(input, self.running_mean, self.running_var, weight=None, bias=None,
-                            training=self.training, momentum=self.momentum, eps=self.eps)
-        return input + self.bias.expand_as(input)
+        output = super().forward(input)
+        return output + self.bias.expand_as(output)

--- a/attorch/layers.py
+++ b/attorch/layers.py
@@ -8,7 +8,7 @@ from torch.nn import Parameter
 
 
 class Offset(nn.Module):
-    def __init__(self, offset=1, **kwargs):
+    def __init__(self, offset=1):
         super().__init__()
         self.offset = offset
 

--- a/attorch/layers.py
+++ b/attorch/layers.py
@@ -48,20 +48,6 @@ class Conv2dPad(nn.Conv2d):
         return F.conv2d(input, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups)
 
 
-class BiasBatchNorm2d(nn.BatchNorm2d):
-    def __init__(self, features, **kwargs):
-        super().__init__(features, affine=False, **kwargs)
-        bias = nn.Parameter(torch.FloatTensor(1, features, 1, 1))
-        self.register_parameter('bias', bias)
-
-    def forward(self, input):
-        self._check_input_dim(input)
-        return F.batch_norm(input, self.running_mean, self.running_var, weight=None, bias=None,
-                            training=self.training, momentum=self.momentum, eps=self.eps)
-        N, _, w, h = input.size()
-        return input + self.bias.repeat(N, 1, w, h)
-
-
 class SpatialXFeatureLinear(nn.Module):
     """
     Factorized fully connected layer. Weights are a sum of outer products between a spatial filter and a feature vector.  

--- a/attorch/layers.py
+++ b/attorch/layers.py
@@ -17,8 +17,6 @@ class Offset(nn.Module):
 
 
 class Elu1(nn.Module):
-    def __init__(self):
-        super().__init__()
 
     def forward(self, x):
         return F.elu(x) + 1.


### PR DESCRIPTION
* Better handling of `affine` keyword argument (it is now no longer possible to overwrite to make it `affine=True`
* Uses the underlying `BatchNorm2d` logic better with `super().forward(input)`
* Remove duplicate `BatchNorm2d` (that was clearly overridden by the second implementation of the `BatchNorm2d` later in the same file)
* Fixed erroneously returning the result of `BatchNorm2d` without adding bias
* Other minor changes and simplifications