### PR TITLE
Add keys to ModuleDict

### DIFF
--- a/attorch/module.py
+++ b/attorch/module.py
@@ -25,4 +25,7 @@ class ModuleDict(nn.Module):
     def __iter__(self):
         return iter(self._modules.values())
 
+    def keys(self):
+        yield from self._modules.keys()
+
 


### PR DESCRIPTION
* Add `keys` method to `ModuleDict` for easier traversal.