### PR TITLE
Updated dependency on PyTorch v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 nvidia-docker-compose.*
+.idea/
+*.swp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,7 @@
-FROM eywalker/tensorflow-jupyter:v1.0.1-cuda8.0-cudnn5
+FROM eywalker/pytorch-jupyter
 
-RUN pip install http://download.pytorch.org/whl/cu80/torch-0.1.12.post2-cp35-cp35m-linux_x86_64.whl && \
-    pip install torchvision
-
-RUN pip3 install jupyter
-
-RUN pip3 install git+https://github.com/datajoint/datajoint-python.git
-
-RUN apt-get update -y \
-    && apt-get install -y graphviz \
-    && pip3 install graphviz \
-    && pip3 install gpustat
+# Install latest DataJoint
+RUN pip3 install --upgrade git+https://github.com/datajoint/datajoint-python.git
 
 ADD . /src/attorch
 RUN pip3 install -e /src/attorch
-
-
-
-WORKDIR /notebooks
-
-

--- a/attorch/dataset.py
+++ b/attorch/dataset.py
@@ -66,7 +66,7 @@ class MultiTensorDataset(Dataset):
         if axis is None:
             return tuple(d.mean() for d in self.data)
         else:
-            return tuple(d.mean(axis) for d in self.data)
+            return tuple(d.mean(axis, keepdim=True) for d in self.data)
 
     def __len__(self):
         return self.data[0].size(0)

--- a/attorch/layers.py
+++ b/attorch/layers.py
@@ -103,8 +103,8 @@ class SpatialXFeatureLinear3D(nn.Module):
     def l1(self, average=True):
         n = self.outdims
         c, _, w, h = self.in_shape
-        ret = (self.spatial.view(self.outdims, -1).abs().sum(1)
-               * self.features.view(self.outdims, -1).abs().sum(1)).sum()
+        ret = (self.spatial.view(self.outdims, -1).abs().sum(1, keepdim=True)
+               * self.features.view(self.outdims, -1).abs().sum(1, keepdim=True)).sum()
         if average:
             ret = ret / (n * c * w * h)
         return ret
@@ -114,7 +114,7 @@ class SpatialXFeatureLinear3D(nn.Module):
         if self.positive:
             positive(self.spatial)
         if self.normalize:
-            weight = self.spatial / (self.spatial.pow(2).sum(2).sum(3).sum(4).sqrt().expand(self.spatial) + 1e-6)
+            weight = self.spatial / (self.spatial.pow(2).sum(2, keepdim=True).sum(3, keepdim=True).sum(4, keepdim=True).sqrt().expand(self.spatial) + 1e-6)
         else:
             weight = self.spatial
         return weight
@@ -382,7 +382,7 @@ class SpatialXFeatureLinear(nn.Module):
         if self.positive:
             positive(self.spatial)
         if self.normalize:
-            weight = self.spatial / (self.spatial.pow(2).sum(2).sum(3).sqrt().expand_as(self.spatial) + 1e-6)
+            weight = self.spatial / (self.spatial.pow(2).sum(2, keepdim=True).sum(3, keepdim=True).sqrt().expand_as(self.spatial) + 1e-6)
         else:
             weight = self.spatial
         return weight
@@ -398,8 +398,8 @@ class SpatialXFeatureLinear(nn.Module):
     def l1(self, average=True):
         n = self.outdims
         c, w, h = self.in_shape
-        ret = (self.normalized_spatial.view(self.outdims, -1).abs().sum(1)
-               * self.features.view(self.outdims, -1).abs().sum(1)).sum()
+        ret = (self.normalized_spatial.view(self.outdims, -1).abs().sum(1, keepdim=True)
+               * self.features.view(self.outdims, -1).abs().sum(1, keepdim=True)).sum()
         if average:
             ret = ret / (n * c * w * h)
         return ret
@@ -466,7 +466,7 @@ class WidthXHeightXFeatureLinear(nn.Module):
         if self.positive:
             positive(self.width)
         if self.normalize:
-            return self.width / (self.width.pow(2).sum(2) + self.eps).sqrt().expand_as(self.width)
+            return self.width / (self.width.pow(2).sum(2, keepdim=True) + self.eps).sqrt().expand_as(self.width)
         else:
             return self.width
 
@@ -476,7 +476,7 @@ class WidthXHeightXFeatureLinear(nn.Module):
         if self.positive:
             positive(self.height)
         if self.normalize:
-            return self.height / (self.height.pow(2).sum(3) + self.eps).sqrt().expand_as(self.height)
+            return self.height / (self.height.pow(2).sum(3, keepdim=True) + self.eps).sqrt().expand_as(self.height)
         else:
             return self.height
 
@@ -562,7 +562,7 @@ class DivNorm3d(nn.Module):
         return ('{name}({num_features}, sigma={sigma})'.format(name=self.__class__.__name__, **self.__dict__))
 
     def forward(self, x):
-        mu = x.mean(1).mean(2).mean(3).mean(4)
+        mu = x.mean(1, keepdim=True).mean(2, keepdim=True).mean(3, keepdim=True).mean(4, keepdim=True)
         y = x - mu.expand_as(x)
         y = y / torch.sqrt(self.sigma + y.pow(2).mean().expand_as(y))
 

--- a/attorch/losses.py
+++ b/attorch/losses.py
@@ -53,13 +53,13 @@ class AvgCorr(nn.Module):
 
     def forward(self, output, target):
         _assert_no_grad(target)
-        delta_out = (output - output.mean(0).expand_as(output))
-        delta_target = (target - target.mean(0).expand_as(target))
+        delta_out = (output - output.mean(0, keepdim=True).expand_as(output))
+        delta_target = (target - target.mean(0, keepdim=True).expand_as(target))
 
-        var_out = delta_out.pow(2).mean(0)
-        var_target = delta_target.pow(2).mean(0)
+        var_out = delta_out.pow(2).mean(0, keepdim=True)
+        var_target = delta_target.pow(2).mean(0, keepdim=True)
 
-        corrs = (delta_out * delta_target).mean(0) / ((var_out + self.eps) * (var_target + self.eps)).sqrt()
+        corrs = (delta_out * delta_target).mean(0, keepdim=True) / ((var_out + self.eps) * (var_target + self.eps)).sqrt()
         return corrs.mean()
 
 
@@ -70,13 +70,13 @@ class Corr(nn.Module):
 
     def forward(self, output, target):
         _assert_no_grad(target)
-        delta_out = (output - output.mean(0).expand_as(output))
-        delta_target = (target - target.mean(0).expand_as(target))
+        delta_out = (output - output.mean(0, keepdim=True).expand_as(output))
+        delta_target = (target - target.mean(0, keepdim=True).expand_as(target))
 
-        var_out = delta_out.pow(2).mean(0)
-        var_target = delta_target.pow(2).mean(0)
+        var_out = delta_out.pow(2).mean(0, keepdim=True)
+        var_target = delta_target.pow(2).mean(0, keepdim=True)
 
-        corrs = (delta_out * delta_target).mean(0) / ((var_out + self.eps) * (var_target + self.eps)).sqrt()
+        corrs = (delta_out * delta_target).mean(0, keepdim=True) / ((var_out + self.eps) * (var_target + self.eps)).sqrt()
         return corrs
 
 
@@ -87,11 +87,11 @@ class UnnormalizedCorr(nn.Module):
 
     def forward(self, output, target):
         _assert_no_grad(target)
-        delta_out = (output - output.mean(0).expand_as(output))
-        delta_target = (target - target.mean(0).expand_as(target))
+        delta_out = (output - output.mean(0, keepdim=True).expand_as(output))
+        delta_target = (target - target.mean(0, keepdim=True).expand_as(target))
 
-        var_out = delta_out.pow(2).mean(0)
-        var_target = delta_target.pow(2).mean(0)
+        var_out = delta_out.pow(2).mean(0, keepdim=True)
+        var_target = delta_target.pow(2).mean(0, keepdim=True)
 
-        corrs = (delta_out * delta_target).sum(0) / ((var_out + self.eps) * (var_target + self.eps)).sqrt()
+        corrs = (delta_out * delta_target).sum(0, keepdim=True) / ((var_out + self.eps) * (var_target + self.eps)).sqrt()
         return corrs, delta_out.size(0)


### PR DESCRIPTION
* Dockerfile now builds against PyTorch v0.2.0
* Reduction ops on Tensors (i.e. `sum` and `mean`) are updated to be compatible with the new default `keepdim=False` by explicitly passing in `keepdim=True`