### PR TITLE
Pytorch0.4.0

### DIFF
--- a/attorch/optimizers.py
+++ b/attorch/optimizers.py
@@ -59,12 +59,12 @@ class ActiveSGD(optim.SGD):
         return loss
 
 
-def cosine_lr_sched(lr_min, lr_max, period_init=10, period_mult=2, n=1000):
+def cosine_schedule(max_value, min_value, period_init=10, period_mult=2, n=1000):
     """ Generator that produces cosine learning rate schedule,
         as defined in Loshchilov & Hutter, 2017, https://arxiv.org/abs/1608.03983
     Arguments:
-        lr_min (float): minimum learning rate
-        lr_max (float): maximum learning rate
+        max_value (float): maximum value
+        min_value (float): minimum value
         period_init (int): intial learning rate restart period
         period_mult (int): period multiplier that is applied at each restart
         n (int): number of iterations
@@ -75,7 +75,7 @@ def cosine_lr_sched(lr_min, lr_max, period_init=10, period_mult=2, n=1000):
     epoch = 0
     period = period_init
     while i < n:
-        lr = lr_min + (lr_max - lr_min) * \
+        lr = min_value + (max_value - min_value) * \
             (1 + math.cos(math.pi * epoch / period)) / 2
         yield lr
         i += 1

--- a/attorch/train.py
+++ b/attorch/train.py
@@ -90,6 +90,7 @@ def early_stopping(model, objective, interval=5, patience=20, start=0, max_iter=
             if (~np.isfinite(current_objective)).any():
                 print('Objective is not Finite. Stopping training')
                 finalize(model, best_state_dict)
+                return
             yield epoch, current_objective
 
         current_objective = _objective(model)

--- a/attorch/train.py
+++ b/attorch/train.py
@@ -87,7 +87,7 @@ def early_stopping(model, objective, interval=5, patience=20, start=0, max_iter=
             epoch += 1
             if time_obj_tracker is not None:
                 time_obj_tracker.log_objective(current_objective)
-            if not np.isfinite(current_objective):
+            if (~np.isfinite(current_objective)).any():
                 print('Objective is not Finite. Stopping training')
                 finalize(model, best_state_dict)
             yield epoch, current_objective


### PR DESCRIPTION
- escape early stopping when objective is NaN or Inf
- rename cosine_lr_sched -> cosine_sched. Reorder args